### PR TITLE
add functions eltype, ndims, dimlabels for `DTable`

### DIFF
--- a/src/dtable.jl
+++ b/src/dtable.jl
@@ -18,6 +18,10 @@ end
 
 chunks(dt::DTable) = dt.chunks
 
+Base.eltype(dt::DTable) = eltype(chunktype(first(chunks(dt)).chunk))
+IndexedTables.dimlabels(dt::DTable) = dimlabels(chunktype(first(chunks(dt)).chunk))
+Base.ndims(dt::DTable) = ndims(dt.index_space)
+
 """
 Compute any delayed-evaluation in the distributed table.
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -49,7 +49,13 @@ If the mapping is many-to-one, `agg` is used to aggregate the results.
 monotonically increasing function.
 """
 function convertdim(t::DTable, d::DimName, xlat; agg=nothing, vecagg=nothing, name=nothing)
-    cs = chunks(t)
+    if isa(d, Symbol)
+        dn = findfirst(dimlabels(t), d)
+        if dn == 0
+            throw(ArgumentError("table has no dimension \"$d\""))
+        end
+        d = dn
+    end
 
     chunkf(c) = convertdim(c, d, xlat; agg=agg, vecagg=vecagg, name=nothing)
     t1 = mapchunks(delayed(chunkf), t)


### PR DESCRIPTION
Fix `convertdim` for named dimensions --- somewhere this was trying to index a tuple with a symbol.

Also adds some interface functions. Requires latest master of `IndexedTables`.