### PR TITLE
give an error for overlapping chunks

### DIFF
--- a/src/dtable.jl
+++ b/src/dtable.jl
@@ -223,6 +223,12 @@ function Base.length(t::DTable)
     end
 end
 
+function has_overlaps(subdomains)
+    subdomains = sort(subdomains, by = first)
+    lasts = map(last, subdomains)
+    return any(i->searchsortedfirst(lasts, first(subdomains[i])) != i, 1:length(subdomains))
+end
+
 """
 `fromchunks(chunks::AbstractArray)`
 
@@ -234,6 +240,11 @@ function fromchunks(chunks::AbstractArray)
     subdomains = map(domain, chunks)
     nzidxs = find(x->!isempty(x), subdomains)
     subdomains = subdomains[nzidxs]
+
+    if has_overlaps(subdomains)
+        error("chunks must be non-overlapping")
+    end
+
     kvtypes = getkvtypes.(chunktype.(chunks))
     K, V = kvtypes[1]
     for (Tk, Tv) in kvtypes[2:end]


### PR DESCRIPTION
Pretty soon this probably won't be necessary, but for now I think it's a useful warning that some operations might not work as expected.