### PR TITLE
automatically add a 1:n index space if there are no indices

### DIFF
--- a/src/load-save.jl
+++ b/src/load-save.jl
@@ -68,7 +68,7 @@ function ingest!(files::AbstractVector, outputdir::AbstractString; delim = ',', 
     println("Reading $(length(files)) csv files totalling $(round(sz/2^20)) MB...")
 
     function load_and_save(file)
-        data = loadTable(file, delim; opts...)
+        data, _ = loadTable(file, delim; opts...)
         save_as_chunk(data, joinpath(outputdir, normalize_filepath(file)))
     end
 

--- a/src/load.jl
+++ b/src/load.jl
@@ -79,9 +79,26 @@ function loadfiles(files::AbstractVector, delim=','; usecache=true, opts...)
     data = map(delayed(load_f), unknown)
 
     chunkrefs = gather(delayed(vcat)(data...))
+
+    if !isnull(chunkrefs[1].handle.offset)
+        # implicit index mode - fabricate a 1-d index space 1:n
+        if metadata === nothing
+            o = 1
+        else
+            o = last(metadata.data.columns.metadata[end].domain)[1] + 1
+        end
+        for c in chunkrefs
+            c.handle.offset = o
+            n = get(nrows(domain(c)))
+            c.domain = IndexSpace(Interval((o,), (o+n-1,)),
+                                  Interval((o,), (o+n-1,)), Nullable{Int}(n))
+            o += n
+        end
+    end
+
     # store this back in cache
     cache = Table(Columns(unknown, fill(opthash, length(unknown)), names=[:filename, :opthash]),
-                     Columns(mtime.(unknown), Dagger.Chunk[chunkrefs...], names=[:mtime, :metadata]))
+                  Columns(mtime.(unknown), Dagger.Chunk[chunkrefs...], names=[:mtime, :metadata]))
 
     if metadata != nothing
         cache = merge(metadata, cache)
@@ -102,6 +119,7 @@ type CSVChunk
     delim::Char
     cached_on::Vector{Int}
     opts::Dict
+    offset::Nullable{Int}  # index of first item when using implicit indices
 end
 
 Dagger.affinity(c::CSVChunk) = map(OSProc, c.cached_on)
@@ -109,26 +127,38 @@ Dagger.affinity(c::CSVChunk) = map(OSProc, c.cached_on)
 function gather(ctx, csv::CSVChunk)
     if csv.cache && haskey(_read_cache, csv.filename)
         #println("Having to fetch data from $csv.cached_on")
-        _read_cache[csv.filename]
+        data = _read_cache[csv.filename]
     elseif csv.cached_on != [myid()] && !isempty(csv.cached_on)
         # TODO: remove myid() if it's in cached_on
         pid = first(csv.cached_on)
         if pid == myid()
             pid = last(csv.cached_on)
         end
-        remotecall_fetch(c -> gather(ctx, c), pid, csv)
+        data = remotecall_fetch(c -> gather(ctx, c), pid, csv)
     else
         #println("CACHE MISS $csv")
-        data = loadTable(csv.filename, csv.delim; csv.opts...)
+        data, ii = loadTable(csv.filename, csv.delim; csv.opts...)
+
+        if ii && isnull(csv.offset)
+            csv.offset = 1
+        end
+
         if !(myid() in csv.cached_on)
             push!(csv.cached_on, myid())
         end
         _read_cache[csv.filename] = data
     end
+
+    if !isnull(csv.offset) && data.index[1][1] != get(csv.offset)
+        o = get(csv.offset)
+        data.index.columns[1][:] = o:(o+length(data)-1)
+    end
+
+    return data
 end
 
 function makecsvchunk(file, delim; cache=true, opts...)
-    handle = CSVChunk(file, cache, delim, Int[], Dict(opts))
+    handle = CSVChunk(file, cache, delim, Int[], Dict(opts), nothing)
     # We need to actually load the data to get things like
     # the type and Domain. It will get cached if cache is true
     nds = gather(Context(), handle)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,11 +103,11 @@ path = joinpath(dirname(@__FILE__), "..","test","fxsample", "*.csv")
 files = glob(path[2:end], "/")
 const fxdata_dist = loadfiles(files, header_exists=false, type_detect_rows=4, indexcols=1:2)
 allcsv = reduce(string, readstring.(files))
-const fxdata = loadTable(allcsv;
-             csvread=TextParse._csvread,
-             indexcols=1:2,
-             type_detect_rows=4,
-             header_exists=false)
+const fxdata, _ = loadTable(allcsv;
+                            csvread=TextParse._csvread,
+                            indexcols=1:2,
+                            type_detect_rows=4,
+                            header_exists=false)
 
 ingest_output = tempname()
 fxdata_ingest = ingest(files, ingest_output, header_exists=false, type_detect_rows=4, indexcols=1:2)


### PR DESCRIPTION
This implements #22.

I'll describe my approach; wondering whether this is a good way to do this.

First, there are several ways there can be "no indices"
- User passes `indexcols=[]`
- File has only one column
- User specifies that all columns are data columns

At the single-CSV-file level, this condition is detected by `loadTable`. `loadTable` adds a 1:n index column when necessary, and returns a flag indicating that this happened.

Next, a `CSVChunk` has an optional `offset` field. When set, this means we're using implicit index mode, and the first index of the chunk should be that offset. When `gather` loads a CSV chunk it ensures that the offset is applied.

Finally, `loadfiles` adjusts the offsets of the chunks after all of them are loaded.

I haven't yet figured out how to apply this to `ingest!`, since it loads and saves in one step. We could use the same trick as `CSVChunk`, but it seems unnecessary --- since we're saving a new copy of the data anyway, we might as well save the exact data we need, rather than fixing it up after loading.