### PR TITLE
automatically sort when chunks overlap, but allowing repeats

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -107,7 +107,7 @@ function loadfiles(files::AbstractVector, delim=','; usecache=true, opts...)
         serialize(io, cache)
     end
 
-    fromchunks(vcat(validcache, chunkrefs), false)
+    fromchunks(vcat(validcache, chunkrefs))
 end
 
 ## TODO: Can make this an LRU cache


### PR DESCRIPTION
This changes the default to allowoverlap=false, ensuring chunks are globally sorted.