### PR TITLE
fix a few issues with `ingest`

### DIFF
--- a/src/load.jl
+++ b/src/load.jl
@@ -3,7 +3,10 @@ export loadfiles
 const JULIADB_CACHEDIR = ".juliadb_cache"
 const JULIADB_FILECACHE = "filemeta.dat"
 
-files_from_dir(dir) = filter(isfile, [ joinpath(dir, f) for f in readdir(dir) ])
+function files_from_dir(dir)
+    dir = abspath(dir)
+    filter(isfile, [ joinpath(dir, f) for f in readdir(dir) ])
+end
 
 function format_bytes(nb)
     bytes, mb = Base.prettyprint_getunits(nb, length(Base._mem_units), Int64(1024))


### PR DESCRIPTION
- export `ingest!`
- convert all paths to absolute paths before using/storing them
- fix name collision of local var `chunks`
- filter out files that have already been ingested in `ingest!`