### PR TITLE
rename `.juliadb_cache` to just `.juliadb`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -38,7 +38,9 @@ fxdata = loadfiles(files, header_exists=false,
 
 Here we specified that the files don't have a header line (`header_exists`), specified the column names (`colnames`) manually, and also specified that `loadfiles` should use columns 1 and 2 as the index for the data (`indexcols`). The index columns will be used to sort the data for efficient queries. See [the API reference for `loadfiles`](apireference.html#JuliaDB.loadfiles) for all available options.
 
-Notice that the output says `150 rows in 10 chunks`. `loadfiles` creates a distributed table (`DTable`) with as many chunks as the input files. The loaded chunks are distributed across available worker processes. `loadfiles` will also save metadata about the contents of the files in a directory named `.juliadb_cache` under the current working directory. This means, the next time the files are loaded, it will not need to actually parse them to know what's in them. However the files will be parsed once an operation requires the data in it.
+Notice that the output says `150 rows in 10 chunks`. `loadfiles` creates a distributed table (`DTable`) with as many chunks as the input files. The loaded chunks are distributed across available worker processes. `loadfiles` will also save metadata about the contents of the files in a directory named `.juliadb` under the current working directory. This means, the next time the files are loaded, it will not need to actually parse them to know what's in them. However the files will be parsed once an operation requires the data in it.
+
+It is also possible to pass a directory path to `loadfiles`, in which case it will load all files in the directory, and place `.juliadb` in that directory as well.
 
 Another way to load data into JuliaDB is using [`ingest`](@ref ingest). `ingest` reads and saves the data in an efficient memory-mappable storage format for faster re-reading. You can also add new files to an existing dataset using [`ingest!`](@ref ingest!).
 

--- a/src/loadfiles.jl
+++ b/src/loadfiles.jl
@@ -1,6 +1,6 @@
 export loadfiles
 
-const JULIADB_CACHEDIR = ".juliadb_cache"
+const JULIADB_DIR = ".juliadb"
 const JULIADB_FILECACHE = "filemeta.dat"
 
 function files_from_dir(dir)
@@ -48,7 +48,7 @@ function loadfiles(files::Union{AbstractVector,String}, delim=','; usecache=true
         if !isdir(files)
             throw(ArgumentError("Specified path does not refer to an existing directory."))
         end
-        cachedir = joinpath(files, JULIADB_CACHEDIR)
+        cachedir = joinpath(files, JULIADB_DIR)
         files = files_from_dir(files)
     else
         for file in files
@@ -56,7 +56,7 @@ function loadfiles(files::Union{AbstractVector,String}, delim=','; usecache=true
                 throw(ArgumentError("No file named $file."))
             end
         end
-        cachedir = JULIADB_CACHEDIR
+        cachedir = JULIADB_DIR
     end
 
     if isempty(files)

--- a/test/test_readwrite.jl
+++ b/test/test_readwrite.jl
@@ -86,7 +86,7 @@ fxdata_ingest_unordered = ingest!(files, ingest_output_unordered,
 import Dagger: Chunk, MemToken
 import JuliaDB: OnDisk
 @testset "Load" begin
-    cache = joinpath(JuliaDB.JULIADB_CACHEDIR, JuliaDB.JULIADB_FILECACHE)
+    cache = joinpath(JuliaDB.JULIADB_DIR, JuliaDB.JULIADB_FILECACHE)
     if isfile(cache)
         rm(cache)
     end


### PR DESCRIPTION
I like this name better since it's shorter, and may make more sense in the future if we put things other than a cache in this directory.