### PR TITLE
Well-defined promotion of chunk types

### DIFF
--- a/src/dtable.jl
+++ b/src/dtable.jl
@@ -293,8 +293,8 @@ function getkvtypes(xs::AbstractArray)
     kvtypes = getkvtypes.(chunktype.(xs))
     K, V = kvtypes[1]
     for (Tk, Tv) in kvtypes[2:end]
-        K = promote_type(Tk, K)
-        V = promote_type(Tv, V)
+        K = map_params(promote_type, Tk, K)
+        V = map_params(promote_type, Tv, V)
     end
     K, V
 end


### PR DESCRIPTION
Previously you could easily end up with `UnionAll`s for `K,V` in `DTable` parameters causing trouble in serializing NamedTuple params. With https://github.com/JuliaComputing/IndexedTables.jl/pull/43, we can know the exact eltypes of the merged table, so this change figures it out.

This also adds `promoted_similar` methods for promoting NullableArray columns with non-nullable ones.

Some uses of `Base.@pure` here are exactly as wrong as those in Base. :-)