### PR TITLE
WIP: Sort optimizations

### DIFF
--- a/src/dtable.jl
+++ b/src/dtable.jl
@@ -116,7 +116,7 @@ end
 
 _merge(f, x::Table) = x
 function _merge(f, x::Table, y::Table, ys::Table...)
-    _merge(f, _merge(f, x,y), _merge(f, ys...))
+    treereduce((a,b)->_merge(f, a, b), [x,y,ys...])
 end
 
 _merge(x::Table, y::Table...) = _merge((a,b) -> merge(a, b, agg=nothing), x, y...)
@@ -236,7 +236,9 @@ function Base.length(t::DTable)
 end
 
 function has_overlaps(subdomains, closed=false)
-    subdomains = sort(subdomains, by = first)
+    if !issorted(subdomains, by=first)
+        subdomains = sort(subdomains, by = first)
+    end
     lasts = map(last, subdomains)
     for i = 1:length(subdomains)
         s_i = first(subdomains[i])

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -105,7 +105,7 @@ function shuffle_merge(ctx::Dagger.Context, cs::AbstractArray,
             while sum(lasts) < rank
                 reqd = rank - sum(lasts)
                 if i > length(idxs)
-                    error("Median of wrong rank found")
+                    break
                 end
                 available = min(reqd, length(idxs[i])) # We add more elements
                                                        # keeping sort stability

--- a/src/sort.jl
+++ b/src/sort.jl
@@ -44,14 +44,14 @@ function sampleselect(ctx, idx, ranks, order; samples=32)
     sample_chunks = map(delayed(sample(samples)), idx.chunks)
     sampleidx = sort!(gather(delayed(vcat)(sample_chunks...)), order=order)
 
-    samplecuts = round.(Int, (ranks ./ length(domain(idx))) .* length(sampleidx))
+    samplecuts = map(x->round(Int, x), (ranks ./ length(domain(idx))) .* length(sampleidx))
     splitteridxs = max.(1, min.(samplecuts, length(sampleidx)))
     splitters = sampleidx[splitteridxs]
     find_ranges(x) = map(splitters) do s
         searchsorted(x, s)
     end
     xs = gather(delayed(hcat)(map(delayed(find_ranges), idx.chunks)...))
-    [splitters[i]=>xs[i, :] for i in 1:size(xs,1)]
+    Pair[splitters[i]=>xs[i, :] for i in 1:size(xs,1)]
 end
 
 immutable All


### PR DESCRIPTION
This attempts to alleviate performance problems in the case where there are 1000s of files being read. `pselect` algorithm of selecting exact splitters was too slow for this case requiring many rounds of all-to-one/one-to-all communications.

This change brings:
- A `sampleselect` algorithm, which selects (currently at most 32) random indices from each chunk, sorts them and figures out elements that are likely to split the entire dataset into equal chunks. This is now the default method for selecting splitters.
- Performs another round of communication to figure out the index of each such splitter in each chunk
- Constructs a vector of vectors of parts making up the output chunk (each vector of subchunks makes a single output chunks)
- Figures out the affinity (if none, picks a random worker) for each sub chunk and figures out a possible destination (currently using `output_chunk_number % nworkers() + 1`)
- Performs an all-to-all communication step
- Returns the result with a lazily evaluated final `merge` for each chunk.
- make merge work in a tree-reduce fashion - makes it (`O(n*log(k))` instead of `O(n*k)`)
- The output preserves the same number of chunks as in the input

While this makes the difference between hours to minutes in a large dataset, it also makes `rechunk` and hence most non-embarassingly-parallel operations in-memory only. I'm optimistic we can address this in the future.

