### PR TITLE
Diagnostics

### DIFF
--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -21,4 +21,6 @@ include("indexing.jl")
 include("query.jl")
 include("join.jl")
 
+include("diagnostics.jl")
+
 end # module

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,0 +1,104 @@
+import Dagger: debug_compute, get_logs!, LocalEventLog
+
+export start_tracking_time, stop_tracking_time, tracktime, fetch_timings!
+
+function time_table(log; profile=false)
+
+    idx = Columns(proc=map(x->x.pid, getfields(log, :timeline)),
+                  event_type=getfields(log, :category),
+                  event_id=getfields(log, :id))
+
+    if profile
+        data = Columns(start=getfields(log, :start),   finish=getfields(log, :finish),
+                       gc_diff=getfields(log, :gc_diff), profile=getfields(log, :profiler_samples))
+    else
+        data = Columns(start=getfields(log, :start),   finish=getfields(log, :finish),
+                       gc_diff=getfields(log, :gc_diff))
+    end
+
+    IndexedTable(idx, data)
+end
+
+function add_gc_diff(x,y)
+    Base.GC_Diff(
+        x.allocd     + y.allocd,
+        x.malloc     + y.malloc,
+        x.realloc    + y.realloc,
+        x.poolalloc  + y.poolalloc,
+        x.bigalloc   + y.bigalloc,
+        x.freecall   + y.freecall,
+        x.total_time + y.total_time,
+        x.pause      + y.pause,
+        x.full_sweep + y.full_sweep
+    )
+end
+
+function aggregate_profile(xs)
+    treereduce(Dagger.mix_samples, xs)
+end
+
+function aggregate_events(xs)
+    sort!(xs, by=x->x.start)
+    gc_diff = reduce(add_gc_diff, map(x -> x.gc_diff, xs))
+    time_spent = sum(map(x -> x.finish - x.start, xs))
+    if isdefined(xs[1], :profile)
+        time_spent, gc_diff, aggregate_profile(map(x->x.profile, xs))
+    end
+    time_spent, gc_diff
+end
+
+function show_timings(t; maxdepth=5)
+    # first aggregate by type of event
+    t1 = reducedim_vec(aggregate_events, t, [:proc, :event_id])
+
+    foreach(t1.index, t1.data) do i, x
+        time_spent, gc_diff = x
+        print(string(i[1]),": ")
+        Base.time_print(time_spent, gc_diff.allocd, gc_diff.total_time, Base.gc_alloc_count(gc_diff))
+    end
+
+    t2 = reducedim_vec(aggregate_events, t, :event_id)
+    println("Breakdown:")
+    println(map(x->first(x)/1e9, t2))
+    if isdefined(t.data.columns, :profile)
+        p = aggregate_profile(t.data.columns.profile)
+        if !isempty(p.samples)
+            println("\nProfile output:")
+            Profile.print(p.samples, p.lineinfo, maxdepth=maxdepth)
+        end
+    end
+end
+
+function getfields(log, fieldname)
+    map(x->getfield(x, fieldname), log)
+end
+
+function start_tracking_time(;profile=false)
+    ctx = get_context()
+    dbgctx = Context(procs(ctx), LocalEventLog(), profile)
+    compute_context[] = dbgctx
+end
+
+function stop_tracking_time()
+    compute_context[] = nothing
+end
+
+"""
+    tracktime(f)
+
+Track the time spent on different processes in different
+categories in running `f`.
+"""
+function tracktime(f; profile=false)
+    start_tracking_time(profile=profile)
+    res = f()
+    ctx = compute_context[]
+    stop_tracking_time()
+    t = fetch_timings!(ctx, profile=profile)
+    show_timings(t)
+    t, res
+end
+
+function fetch_timings!(ctx=get_context(); profile=true)
+    time_table(Dagger.get_logs!(ctx.log_sink), profile=profile)
+end

--- a/src/dtable.jl
+++ b/src/dtable.jl
@@ -1,5 +1,5 @@
 import Dagger: Domain, chunktype, domain, tochunk,
-               chunks, compute, gather
+               chunks, Context, compute, gather
 
 
 # re-export the essentials
@@ -39,6 +39,9 @@ Base.eltype{K,V}(dt::DTable{K,V}) = V
 IndexedTables.dimlabels(dt::DTable) = dimlabels(chunktype(first(dt.chunks))) # XXX: doesn't work if first chunk is a thunk
 Base.ndims{K}(dt::DTable{K}) = nfields(K)
 
+const compute_context = Ref{Union{Void, Context}}(nothing)
+get_context() = compute_context[] == nothing ? Context() : compute_context[]
+
 """
     compute(t::DTable; allowoverlap, closed)
 
@@ -60,7 +63,7 @@ See also [`gather`](@ref).
     If the result is expected to be big, try `compute(save(t, "output_dir"))` instead.
     See [`save`](@ref) for more.
 """
-compute(t::DTable; kwargs...) = compute(Dagger.Context(), t; kwargs...)
+compute(t::DTable; kwargs...) = compute(get_context(), t; kwargs...)
 
 function compute(ctx, t::DTable; allowoverlap=false, closed=false)
     if any(Dagger.istask, t.chunks)
@@ -87,7 +90,7 @@ Gets distributed data in a DTable `t` and merges it into
     try `compute(save(t, "output_dir"))` instead. See [`save`](@ref) for more.
     This data can be loaded later using [`load`](@ref).
 """
-gather(t::DTable) = gather(Dagger.Context(), t)
+gather(t::DTable) = gather(get_context(), t)
 
 function gather{T}(ctx, dt::DTable{T})
     cs = dt.chunks
@@ -130,7 +133,7 @@ Base.map(f, dt::DTable) = mapchunks(c->map(f, c), dt)
 
 function Base.reduce(f, dt::DTable)
     cs = map(delayed(c->reduce(f, c)), dt.chunks)
-    gather(treereduce(delayed(f), cs))
+    gather(get_context(), treereduce(delayed(f), cs))
 end
 
 immutable EmptySpace{T} <: Domain end

--- a/src/ingest.jl
+++ b/src/ingest.jl
@@ -101,7 +101,7 @@ function ingest!(files::Union{AbstractVector,String}, outputdir::AbstractString;
 
     saved = map(delayed(load_and_save), files)
 
-    chunkrefs = gather(delayed(vcat)(saved...))
+    chunkrefs = gather(get_context(), delayed(vcat)(saved...))
 
     if !isnull(chunkrefs[1].handle.offset)
         offset = existing_dtable===nothing ? 1 :

--- a/src/loadfiles.jl
+++ b/src/loadfiles.jl
@@ -107,7 +107,7 @@ function loadfiles(files::Union{AbstractVector,String}, delim=','; usecache=true
     load_f(f) = makecsvchunk(f, delim; opts...)
     data = map(delayed(load_f), unknown)
 
-    chunkrefs = gather(delayed(vcat)(data...))
+    chunkrefs = gather(get_context(), delayed(vcat)(data...))
 
     if !isnull(chunkrefs[1].handle.offset)
         lastidx = reduce(max, 0, first.(last.(domain.(validcache)))) + 1
@@ -207,7 +207,7 @@ function makecsvchunk(file, delim; cache=true, opts...)
     handle = CSVChunk(file, cache, delim, Dict(opts), nothing)
     # We need to actually load the data to get things like
     # the type and Domain. It will get cached if cache is true
-    nds, ii = _gather(Context(), handle)
+    nds, ii = _gather(get_context(), handle)
     if ii
         handle.offset = 1
     end


### PR DESCRIPTION
Some tools to track what's going on during a computation.

`tracktime(f, profile=true)` will execute `f` while tracking time taken by different thunks doing communication / compute. `profile` option (`false` by default) will also collect profile samples across workers.

Example output:

```
julia> logs, y = @time tracktime(;profile=true) do; compute(reducedim(+, dt, 1)); end;
comm:  11.155363 seconds (109.15 k allocations: 1.266 GiB, 17.43% gc time)
compute:   6.732356 seconds (16.64 k allocations: 572.998 MiB, 0.87% gc time)
scheduler:   0.019676 seconds (2.25 k allocations: 127.703 KiB)
scheduler_init:   0.962229 seconds (11.33 k allocations: 697.641 KiB, 77.78% gc time)
Breakdown:
proc  event_type      │ 
──────────────────────┼───────────
1     :comm           │ 1.94722
1     :compute        │ 2.4458e-5
1     :scheduler      │ 0.0196761
1     :scheduler_init │ 0.883757
2     :comm           │ 3.28282
2     :compute        │ 1.52348
2     :scheduler_init │ 0.00130303
3     :comm           │ 2.89057
3     :compute        │ 1.86718
3     :scheduler_init │ 0.0278641
4     :comm           │ 3.00596
4     :compute        │ 1.73609
4     :scheduler_init │ 0.00475171
5     :comm           │ 0.0287867
5     :compute        │ 1.60559
5     :scheduler_init │ 0.0445529

Profile output:
13472 ./event.jl:73; #105
 13472 ./distributed/process_messages.jl:268; macro expansion
  13472 ./distributed/process_messages.jl:56; run_work_thunk
   13472 ./distributed/process_messages.jl:268; #106
    6     ./tuple.jl:158; map
    11927 /home/shashi/.julia/v0.6/Dagger/src/compute.jl:431; do_task
     1073  /home/shashi/.julia/v0.6/JuliaDB/src/query.jl:40; #183
     10854 /home/shashi/.julia/v0.6/JuliaDB/src/query.jl:46; chunk_merge
    18    /home/shashi/.julia/v0.6/Dagger/src/compute.jl:432; do_task
     9 ./<missing>:0; #tochunk
    5     /home/shashi/.julia/v0.6/Dagger/src/compute.jl:437; do_task
     5 /home/shashi/.julia/v0.6/Dagger/src/lib/logging.jl:134; timespan_end
    1     /home/shashi/.julia/v0.6/JuliaDB/src/sort.jl:158; #88
     1 /home/shashi/.julia/v0.6/Dagger/src/lib/logging.jl:126; timespan_start
    1497  /home/shashi/.julia/v0.6/JuliaDB/src/sort.jl:159; #88
     1497 ./distributed/remotecall.jl:367; remotecall_fetch
    1     /home/shashi/.julia/v0.6/JuliaDB/src/sort.jl:167; #88
    17    /home/shashi/.julia/v0.6/JuliaDB/src/sort.jl:162; #89
     17 /home/shashi/.julia/v0.6/Dagger/src/compute.jl:56; gather
6189  ./event.jl:73; (::Base.REPL.##1#2{Base.REPL.REPLBackend})()
 6189 ./REPL.jl:97; macro expansion
  6189 ./REPL.jl:66; eval_user_input(::Any, ::Base.REPL.REPLBackend)
   6189 ./boot.jl:235; eval(::Module, ::Any)
    6189 ./<missing>:0; (::JuliaDB.#kw##tracktime)(::Array{Any,1}, ::JuliaDB.#tracktime, ::Function)
     6189 /home/shashi/.julia/v0.6/JuliaDB/src/diagnostics.jl:94; #tracktime#261(::Bool, ::Function, ::##39#40)
1902  ./event.jl:73; #99
 1902 ./distributed/process_messages.jl:118; process_tcp_streams
  12   ./distributed/process_messages.jl:157; message_handler_loop
   12 ./distributed/messages.jl:170; deserialize_hdr_raw
    12 ./io.jl:359; read
     12 ./io.jl:357; unsafe_read
  1890 ./distributed/process_messages.jl:161; message_handler_loop
   1    ./distributed/messages.jl:0; deserialize_msg
   1885 ./distributed/messages.jl:98; deserialize_msg
    51   ./serialize.jl:672; handle_deserialize
     50 ./serialize.jl:871; deserialize_array
    1833 ./serialize.jl:682; handle_deserialize
     1833 ./serialize.jl:1075; deserialize
  7.599000 seconds (375.85 k allocations: 206.303 MiB, 30.65% gc time)
```

The return value of `tracktime` is a 2-tuple, first element is the log of all events in the form of an IndexedTable indexed by `proc`, `event_type` and `event_id`. You can use `JuliaDB.aggregate_timings` with `reducedim_vec` or `convertdim_vec` to aggregate samples. Or simply call `JuliaDB.show_timings` to see a summary of any subset of the table.