### PR TITLE
Editing printed message when only one file is loaded.

### DIFF
--- a/src/loadfiles.jl
+++ b/src/loadfiles.jl
@@ -93,16 +93,24 @@ function loadfiles(files::Union{AbstractVector,String}, delim=','; usecache=true
 
     # Give an idea of what we're up against, we should probably also show a
     # progress meter.
-    println("Metadata for ", length(files)-length(unknown), " / ",
+     if length(files)>1
+        println("Metadata for ", length(files)-length(unknown), " / ",
             length(files), " files can be loaded from cache.")
-
+     elseif length(files)==1
+        println("Metadata for ", length(files)-length(unknown), " / ",
+            length(files), " file can be loaded from cache.")
+    end
     if isempty(unknown)
         # we read all required metadata from cache
         return cache_thunks(fromchunks(validcache))
     end
 
     sz = sum(map(filesize, unknown))
-    println("Reading $(length(unknown)) csv files totalling $(format_bytes(sz))...")
+    if length(unknown)>1
+        println("Reading $(length(unknown)) csv files totalling $(format_bytes(sz))...")
+    elseif length(unknown)==1
+        println("Reading $(length(unknown)) csv file totalling $(format_bytes(sz))...")
+    end 
     # Load the data first into memory
     load_f(f) = makecsvchunk(f, delim; opts...)
     data = map(delayed(load_f), unknown)


### PR DESCRIPTION
This is just a pet peeve of mine, where originally, the printed message would be "Loading x files..." regardless of the number of files. It just feels better for it to say "Loading one file..." when it is only a single file. 
It's honestly not even really a problem, I just noticed it and felt the urge to make an edit.