### PR TITLE
Revert "depend on the latest Dagger"

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 IndexedTables 0.3.0
 NamedTuples 4.0.0
 TextParse 0.1.6
-Dagger 0.2.2
+Dagger 0.2.0
 Glob 1.1.1
 PooledArrays 0.0.2
 NullableArrays


### PR DESCRIPTION
This reverts commit c1014c266b991165c279d26fb593d577075a5fef.

Tests look like they pass fine against Dagger 0.2.0