### PR TITLE
WIP: Show list of index and data names and types

### DIFF
--- a/src/printing.jl
+++ b/src/printing.jl
@@ -14,25 +14,53 @@ function take_n(t::DTable, n)
     return top
 end
 
+_indexnames(c::Dagger.Chunk) = [c.chunktype.types[3].types[1].name.names...]
+_datanames( c::Dagger.Chunk) = [c.chunktype.types[4].types[1].name.names...]
+_indexnames(t::DTable) = _indexnames(first(t.chunks))
+_datanames( t::DTable) = _datanames( first(t.chunks))
+
+_indextypes(c::Dagger.Chunk) = map(eltype, c.chunktype.types[3].types[1].types)
+_datatypes( c::Dagger.Chunk) = map(eltype, c.chunktype.types[4].types[1].types)
+_indextypes(t::DTable) = _indextypes(first(t.chunks))
+_datatypes( t::DTable) = _datatypes( first(t.chunks))
+
 function Base.show(io::IO, t::DTable)
     # we fetch at most 21 elements and let IndexedTable
     # display it.
     len = trylength(t)
     if !isempty(t.chunks)
-        top = take_n(t, 5)
+        # top = take_n(t, 5)
         nchunks = length(t.chunks)
         print(io, "DTable with ")
         if !isnull(len)
             print(io, "$(get(len)) rows in ")
         end
 
-        println(io, "$nchunks chunks:")
-        println(io, "")
-        show(io, top)
-        if isnull(len) || get(len) > 5
-            println(io, "")
-            print(io, "...")
-        end
+        println(io, "$nchunks chunks.\n")
+
+        # Index
+        index_names = _indexnames(t)
+        index_types = _indextypes.(t)
+        data_names  = _datanames(t)
+        data_types  = _datatypes.(t)
+
+        lngth = max(maximum(length∘string, index_names), maximum(length∘string, data_names)) + 5
+
+        # Index
+        println(io, rpad("Index names:", lngth), "Index type:")
+        println.(io, rpad.(index_names, lngth) .* string.(index_types))
+        println()
+
+        # Data
+        println(io, rpad("Data names:", lngth), "Data type:")
+        println.(io, rpad.(data_names, lngth) .* string.(data_types))
+
+        # println(io, "")
+        # show(io, top)
+        # if isnull(len) || get(len) > 5
+        #     println(io, "")
+        #     print(io, "...")
+        # end
     else
         println(io, "an empty DTable")
     end


### PR DESCRIPTION
...instead of the actual table to improve printing of large tables. For GDELT, it gives something like
```julia
Metadata for 0 / 1 files can be loaded from cache.
Reading 1 csv files totalling 36.930 MiB...
DTable with 3288 rows in 1 chunks.

Index names:                     Index type:
GKGRECORDID                      String
V2_1DATE                         Int64
V2SOURCECOLLECTIONIDENTIFIER     Int64
V2SUBSOURCECOMMONNAME            String
V2DOCUMENTIDENTIFIER             String

Data names:                      Data type:
V1COUNTS                         String
V2_1COUNTS                       String
V1THEMES                         String
V2ENHANCEDTHEMES                 String
V1LOCATIONS                      String
V2ENHANCEDLOCATIONS              String
V1PERSONS                        String
V2ENHANCEDPERSONS                String
V1ORGANIZATIONS                  String
V2ENHANCEDORGANIZATIONS          String
V1_5TONE                         String
V2_1ENHANCEDDATES                String
V2GCAM                           String
V2_1SHARINGIMAGE                 String
V2_1RELATEDIMAGES                String
V2_1SOCIALIMAGEEMBEDS            String
V2_1SOCIALVIDEOEMBEDS            String
V2_1QUOTATIONS                   String
V2_1ALLNAMES                     String
V2_1AMOUNTS                      String
V2_1TRANSLATIONINFO              Nullable{Union{}}
V2EXTRASXML                      String
```