### PR TITLE
WIP Query.jl integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,3 +10,4 @@ PooledArrays 0.0.2
 OnlineStats v0.13.0
 StatsBase
 DataValues
+QueryOperators

--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -9,6 +9,7 @@ import TextParse: csvread
 import IndexedTables: Table
 import Dagger: compute, distribute, free!, gather, load, save
 using DataValues
+import QueryOperators
 
 # re-export
 export IndexedTable, NDSparse, NextTable, Columns, colnames,
@@ -46,6 +47,8 @@ include("selection.jl")
 include("reduce.jl")
 include("flatten.jl")
 include("join.jl")
+
+include("queryintegration.jl")
 
 include("diagnostics.jl")
 

--- a/src/queryintegration.jl
+++ b/src/queryintegration.jl
@@ -1,0 +1,15 @@
+function QueryOperators.query(source::IndexedTables.NextTable)
+    return source
+end
+
+function QueryOperators.map(source::IndexedTables.NextTable, f_as_anon, f_as_expr)
+    # TODO Anaylze f_as_expr to find out which columns are actually used,
+    # then pass those column names as the select argument
+    return map(f_as_anon, source)
+end
+
+function QueryOperators.filter(source::IndexedTables.NextTable, f_as_anon, f_as_expr)
+    # TODO Anaylze f_as_expr to find out which columns are actually used,
+    # then pass those column names as the select argument    
+    return filter(f_as_anon, source)
+end


### PR DESCRIPTION
This will take _a lot_ of work to complete, and those two functions were the low-hanging fruit. But this by itself enables things like this:
````julia
using JuliaDB, Query

t = table(...) # create some table

t2 = @from i in t begin
     @where i.a > 3
     @select {i.b, newcol=i.b^2}
end

t3 = t |> @filter(_.a>3) |> @map({_.b, newcol=_.b^2})
````
I think the other query operators though aren't such a nice fit between the two systems, although I probably should dig a bit deeper.

I'm not sure I will have the time to finish this, mostly just wanted to show that this in principle could be done.