### PR TITLE
WIP: docs on OnlineStats integration

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ makedocs(
        "Aggregation" => "api/aggregation.md",
        "Joins" => "api/joins.md",
        "Loading and Saving" => "api/io.md",
+       "OnlineStats Integration" => "api/onlinestats.md"
    ],
    assets = ["assets/custom.css", "assets/custom.js"]
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,7 @@ makedocs(
        "Aggregation" => "api/aggregation.md",
        "Joins" => "api/joins.md",
        "Loading and Saving" => "api/io.md",
-       "OnlineStats Integration" => "api/onlinestats.md"
+       "OnlineStats Integration" => "manual/onlinestats.md"
    ],
    assets = ["assets/custom.css", "assets/custom.js"]
 )

--- a/docs/src/api/onlinestats.md
+++ b/docs/src/api/onlinestats.md
@@ -1,0 +1,46 @@
+# OnlineStats Integration
+
+[OnlineStats.jl](https://github.com/joshday/OnlineStats.jl) is a package for calculating 
+statistics and models with online (one observation at a time) parallelizable algorithms.  
+This integrates tightly with JuliaDB's distributed data structures to calculate statistics
+on large datasets.
+
+For the full OnlineStats documentation, see [http://joshday.github.io/OnlineStats.jl/stable/](http://joshday.github.io/OnlineStats.jl/stable/).
+
+## Basics
+
+Each statistic/model is a subtype of `OnlineStat`.  `OnlineStat`s are grouped together in 
+a `Series`.  In JuliaDB, the functions [`reduce`](@ref) and [`groupreduce`](@ref) can accept:
+
+1. An `OnlineStat`
+1. A tuple of `OnlineStat`s
+1. A `Series`
+
+## Usage on a single column
+
+```@repl ex1
+using JuliaDB, OnlineStats
+
+t = table(@NT(x = randn(100), y = randn(100)));
+```
+
+### `reduce` via `OnlineStat`
+
+```@repl ex1
+reduce(Mean(), t; select = :x)
+```
+
+### `reduce` via `Series`
+```@repl ex1 
+s = Series(Mean(), Variance(), Sum());
+reduce(s, t; select = :x)
+```
+
+## Usage on multiple columns
+
+If we want the same statistic calculated for each column in the selection, we need to specify
+the number of columns. 
+
+```@repl ex1
+reduce(2Mean(), t; select = (:x, :y))
+```

--- a/docs/src/manual/onlinestats.md
+++ b/docs/src/manual/onlinestats.md
@@ -1,11 +1,13 @@
 # OnlineStats Integration
 
-[OnlineStats.jl](https://github.com/joshday/OnlineStats.jl) is a package for calculating 
+[**OnlineStats**](https://github.com/joshday/OnlineStats.jl) is a package for calculating 
 statistics and models with online (one observation at a time) parallelizable algorithms.  
 This integrates tightly with JuliaDB's distributed data structures to calculate statistics
 on large datasets.
 
 For the full OnlineStats documentation, see [http://joshday.github.io/OnlineStats.jl/stable/](http://joshday.github.io/OnlineStats.jl/stable/).
+
+---
 
 ## Basics
 
@@ -24,6 +26,8 @@ using JuliaDB, OnlineStats
 
 t = table(@NT(x = randn(100), y = randn(100), z = rand(1:5, 100)))
 ```
+
+---
 
 ## Usage on a single column
 
@@ -44,6 +48,8 @@ reduce((Mean(), Variance()), t; select = :x)
 s = Series(Mean(), Variance(), Sum());
 reduce(s, t; select = :x)
 ```
+
+---
 
 ## Usage on multiple columns
 

--- a/docs/src/manual/onlinestats.md
+++ b/docs/src/manual/onlinestats.md
@@ -16,18 +16,27 @@ a `Series`.  In JuliaDB, the functions [`reduce`](@ref) and [`groupreduce`](@ref
 1. A tuple of `OnlineStat`s
 1. A `Series`
 
-## Usage on a single column
+
+### Example Table
 
 ```@repl ex1
 using JuliaDB, OnlineStats
 
-t = table(@NT(x = randn(100), y = randn(100)));
+t = table(@NT(x = randn(100), y = randn(100), z = rand(1:5, 100)))
 ```
+
+## Usage on a single column
 
 ### `reduce` via `OnlineStat`
 
 ```@repl ex1
 reduce(Mean(), t; select = :x)
+```
+
+### `reduce` via Tuple of `OnlineStat`s
+
+```@repl ex1
+reduce((Mean(), Variance()), t; select = :x)
 ```
 
 ### `reduce` via `Series`
@@ -38,9 +47,22 @@ reduce(s, t; select = :x)
 
 ## Usage on multiple columns
 
+### Same `OnlineStat` on each column
+
 If we want the same statistic calculated for each column in the selection, we need to specify
 the number of columns. 
 
 ```@repl ex1
 reduce(2Mean(), t; select = (:x, :y))
+```
+
+### Different `OnlineStat`s on columns
+
+To calculate different statistics on different columns, we need to make a `Group`, which can
+be created via `hcat`.
+
+```@repl ex1 
+s = reduce([Mean() CountMap(Int)], t; select = (:x, :z))
+
+value(stats(s)[1])
 ```


### PR DESCRIPTION
This is the start of more documentation for using OnlineStats with JuliaDB.

After the next OnlineStats release, I can add in some of the [Partition](http://joshday.github.io/OnlineStats.jl/latest/visualizations.html#Partitions-1) plots.
  