### PR TITLE
ML schema fixes

### DIFF
--- a/src/ml.jl
+++ b/src/ml.jl
@@ -38,7 +38,7 @@ struct Continuous
 end
 
 function schema(xs, ::Type{Continuous})
-    Continuous(Series(xs, Mean(), Variance()))
+    Continuous(Series(xs, Variance()))
 end
 function schema(xs::AbstractArray{<:Real})
     schema(xs, Continuous)
@@ -47,8 +47,8 @@ width(::Continuous) = 1
 function merge(c1::Continuous, c2::Continuous)
     Continuous(merge(c1.series, c2.series))
 end
-Base.mean(c::Continuous)::Float64 = value(c.series)[1]
-Base.std(c::Continuous)::Float64 = c.series.stats[2].σ2
+Base.mean(c::Continuous)::Float64 = mean(c.series.stats[1])
+Base.std(c::Continuous)::Float64 = std(c.series.stats[1])
 function Base.show(io::IO, c::Continuous)
     write(io, "Continous(μ=$(mean(c)), σ=$(std(c)))")
 end
@@ -87,14 +87,15 @@ function schema(xs::PooledArray)
     schema(xs, Categorical)
 end
 
-dict(c::Categorical) = c.series.stats[1].d
-width(c::Categorical) = length(dict(c))
+Base.keys(c::Categorical) = keys(c.series.stats[1])
+# dict(c::Categorical) = c.series.stats[1].d
+width(c::Categorical) = length(keys(c))
 merge(c1::Categorical, c2::Categorical) = Categorical(merge(c1.series, c2.series))
 function Base.show(io::IO, c::Categorical)
     write(io, "Categorical($(collect(keys(dict(c)))))")
 end
 Base.@propagate_inbounds function featuremat!(A, c::Categorical, xs, dropna=Val{false}())
-    ks = collect(keys(dict(c)))
+    ks = keys(c)
     labeldict = Dict{eltype(ks), Int}(zip(ks, 1:length(ks)))
     for i = 1:length(xs)
         if dropna isa Val{true} && isnull(xs[i])

--- a/src/ml.jl
+++ b/src/ml.jl
@@ -88,11 +88,10 @@ function schema(xs::PooledArray)
 end
 
 Base.keys(c::Categorical) = keys(c.series.stats[1])
-# dict(c::Categorical) = c.series.stats[1].d
 width(c::Categorical) = length(keys(c))
 merge(c1::Categorical, c2::Categorical) = Categorical(merge(c1.series, c2.series))
 function Base.show(io::IO, c::Categorical)
-    write(io, "Categorical($(collect(keys(dict(c)))))")
+    write(io, "Categorical($(collect(keys(c))))")
 end
 Base.@propagate_inbounds function featuremat!(A, c::Categorical, xs, dropna=Val{false}())
     ks = keys(c)

--- a/test/test_ml.jl
+++ b/test/test_ml.jl
@@ -6,7 +6,7 @@ using DataValues
 
 @testset "feature extraction" begin
     @testset "schema" begin
-        @test ML.schema([1:10;]).series == Series([1:10;], Mean(), Variance())
+        @test ML.schema([1:10;]).series == Series([1:10;], Variance())
         x = repeat([1,2], inner=5)
         @test ML.schema(x, ML.Categorical).series == Series(x, CountMap(Int)) == ML.schema(PooledArray(x)).series
         m = ML.schema(DataValueArray(x))

--- a/test/test_ml.jl
+++ b/test/test_ml.jl
@@ -19,7 +19,7 @@ using DataValues
     end
 
     @testset "featuremat" begin
-        @test ML.featuremat([1,2,3]) == [-1.5, 0, 1.5]'
+        @test ML.featuremat([1,3,5]) == [-1.0, 0, 1.0]'
         @test ML.featuremat(DataValueArray([1,2,3], Bool[0,0,1])) == [0 0 1; -2 2 0]
         @test ML.featuremat(DataValueArray([1,2,3], Bool[0,0,1])) == [0 0 1; -2 2 0]
         @test isempty(ML.featuremat(["x","y","x"]))

--- a/test/test_ml.jl
+++ b/test/test_ml.jl
@@ -27,5 +27,8 @@ using DataValues
 
         t = table(PooledArray([1,1,2,2]), [1,2,3,4], DataValueArray([1,2,3,4]), ["x", "y", "z", "a"], names=[:a,:b,:c,:d])
         @test ML.featuremat(t) == collect(ML.featuremat(distribute(t, 2)))
+
+        x = randn(100)
+        @test ML.featuremat(x) ≈ ((x .- mean(x)) ./ std(x))'
     end
 end


### PR DESCRIPTION
This fixes a few things/does less reaching into OnlineStats internals.

- Currently, standardization/show method is incorrect (biased variance and not std).
- `Variance` also calculates the mean, so we don't need both.
- Changes methods with `CountMap` so that it works with current release as well as new structure in master.