### PR TITLE
Add dropmissing option partitionplot

### DIFF
--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -18,7 +18,7 @@ getvalue(x::DataValues.DataValue) = get(x)
         sel_y = o.args[3]
         T = fieldtype(eltype(t), IndexedTables.colindex(t, sel_x))
         s = dropmissing ? 
-            series(IndexedPartition(T, stat, nparts); filter = x->any(!isnull, x), transform = x->map(getvalue,x)) :
+            series(IndexedPartition(T, stat, nparts); filter = x->all(!isnull, x), transform = x->map(getvalue,x)) :
             series(IndexedPartition(T, stat, nparts))
         if by == nothing 
             reduce(s, t; select = (sel_x, sel_y))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -18,10 +18,10 @@ getvalue(x::DataValues.DataValue) = get(x)
         sel_y = o.args[3]
         T = fieldtype(eltype(t), IndexedTables.colindex(t, sel_x))
         s = dropmissing ? 
-            series(IndexedPartition(T, stat, nparts)) :
-            series(IndexedPartition(T, stat, nparts); filter = !isnull, transform = getvalue)
+            series(IndexedPartition(T, stat, nparts); filter = x->any(!isnull, x), transform = x->map(getvalue,x)) :
+            series(IndexedPartition(T, stat, nparts))
         if by == nothing 
-            label --> OnlineStats.name(stat,false,false) * " of $sel_y"
+            # label --> OnlineStats.name(stat,false,false) * " of $sel_y"
             reduce(s, t; select = (sel_x, sel_y))
         else 
             out = collect(groupreduce(s, t, by; select = (sel_x, sel_y)))
@@ -34,8 +34,8 @@ getvalue(x::DataValues.DataValue) = get(x)
         end
     elseif length(o.args) == 2 
         s = dropmissing ? 
-            series(Partition(stat, nparts)) : 
-            series(Partition(stat, nparts); filter = !isnull, transform = getvalue)
+            series(Partition(stat, nparts); filter = !isnull, transform = getvalue) :
+            series(Partition(stat, nparts))
         if by == nothing
             label --> OnlineStats.name(stat,false,false) * " of $sel_x"
             reduce(s, t; select = sel_x)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -52,8 +52,8 @@ getvalue(x::DataValues.DataValue) = get(x)
 end
 
 """
-    partitionplot(table, y;    stat=Extrema(), nparts=100, by=nothing)
-    partitionplot(table, x, y; stat=Extrema(), nparts=100, by=nothing)
+    partitionplot(table, y;    stat=Extrema(), nparts=100, by=nothing, dropmissing=false)
+    partitionplot(table, x, y; stat=Extrema(), nparts=100, by=nothing, dropmissing=false)
 
 Plot a summary of variable `y` against `x` (`1:length(y)` if not specified).  Using `nparts`
 approximately-equal sections along the x-axis, the data in `y` over each section is 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -21,7 +21,6 @@ getvalue(x::DataValues.DataValue) = get(x)
             series(IndexedPartition(T, stat, nparts); filter = x->any(!isnull, x), transform = x->map(getvalue,x)) :
             series(IndexedPartition(T, stat, nparts))
         if by == nothing 
-            # label --> OnlineStats.name(stat,false,false) * " of $sel_y"
             reduce(s, t; select = (sel_x, sel_y))
         else 
             out = collect(groupreduce(s, t, by; select = (sel_x, sel_y)))
@@ -37,7 +36,6 @@ getvalue(x::DataValues.DataValue) = get(x)
             series(Partition(stat, nparts); filter = !isnull, transform = getvalue) :
             series(Partition(stat, nparts))
         if by == nothing
-            label --> OnlineStats.name(stat,false,false) * " of $sel_x"
             reduce(s, t; select = sel_x)
         else 
             out = groupreduce(s, t, by; select = sel_x)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -29,7 +29,7 @@ indextype(x::Type{DataValues.DataValue{T}}) where {T} = T
             out = collect(groupreduce(s, t, by; select = (sel_x, sel_y)))
             for i in 1:length(out)
                 @series begin 
-                    label --> OnlineStats.name(stat,false,false) * " of $(out[i][1])"
+                    label --> OnlineStats.name(stat,false,false) * " of $sel_x ($(out[i][1]))"
                     out[i][2]
                 end
             end
@@ -44,7 +44,7 @@ indextype(x::Type{DataValues.DataValue{T}}) where {T} = T
             out = groupreduce(s, t, by; select = sel_x)
             for i in 1:length(out)
                 @series begin 
-                    label --> OnlineStats.name(stat,false,false) * " of $(out[i][1])"
+                    label --> OnlineStats.name(stat,false,false) * " of $sel_x ($(out[i][1]))"
                     out[i][2]
                 end
             end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -10,15 +10,18 @@ end
 getvalue(x) = x 
 getvalue(x::DataValues.DataValue) = get(x)
 
+indextype(x::Type) = x 
+indextype(x::Type{DataValues.DataValue{T}}) where {T} = T
+
 @recipe function f(o::PartitionPlot; nparts = 100, stat = nothing, by = nothing, dropmissing = false)
     t = o.args[1]
     sel_x = o.args[2] 
     stat = (stat == nothing) ? Extrema() : stat
     if length(o.args) == 3
         sel_y = o.args[3]
-        T = fieldtype(eltype(t), IndexedTables.colindex(t, sel_x))
+        T = indextype.(fieldtype(eltype(t), IndexedTables.colindex(t, sel_x)))
         s = dropmissing ? 
-            series(IndexedPartition(T, stat, nparts); filter = x->all(!isnull, x), transform = x->map(getvalue,x)) :
+            series(IndexedPartition(T, stat, nparts); filter = x->all(!isnull, x), transform = x->getvalue.(x)) :
             series(IndexedPartition(T, stat, nparts))
         if by == nothing 
             reduce(s, t; select = (sel_x, sel_y))


### PR DESCRIPTION
Related to @piever's suggestion in https://github.com/JuliaComputing/JuliaDB.jl/pull/117#issuecomment-362300330, this PR adds a `dropmissing` keyword arg to `partitionplot` to filter out missing data.

It's a pretty small change.  I'll merge when CI passes.
