### PR TITLE
[DO NOT MERGE] naive implementation of chunking reader

### DIFF
--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -39,6 +39,7 @@ include("iteration.jl")
 include("sort.jl")
 
 include("io.jl")
+include("block-io.jl")
 include("printing.jl")
 
 include("indexing.jl")

--- a/src/block-io.jl
+++ b/src/block-io.jl
@@ -1,0 +1,143 @@
+##
+# give a stream view to a block from any seekable iostream
+# By @tanmaykm
+#
+import Base: close, eof, read, read!, peek, seek, write, filesize, position, seekend, seekstart, skip, nb_available
+
+###############################################################################
+#  BlockIO
+###############################################################################
+
+struct BlockIO <: IO
+    s::IO
+    r::UnitRange
+    l::Int
+
+    function find_end_pos(bio::BlockIO, end_byte::Char)
+        seekend(bio)
+        try
+            while(!eof(bio.s) && (end_byte != read(bio, Char))) continue end
+        end
+        position(bio.s)
+    end
+
+    function find_start_pos(bio::BlockIO, end_byte::Char)
+        (bio.r.start == 1) && (return bio.r.start)
+        seekstart(bio)
+        !eof(bio.s) && while(end_byte != read(bio, Char)) continue end
+        position(bio.s)+1
+    end
+
+    function BlockIO(s::IO, r::UnitRange, match_ends::Union{Char,Void}=nothing)
+        # TODO: use mark when available
+        seekend(s)
+        ep = position(s)
+
+        r = min(r.start,ep+1):min(r.start+length(r)-1,ep)
+        bio = new(s, r, length(r))
+        if(nothing != match_ends)
+            p1 = find_start_pos(bio, match_ends)
+            p2 = find_end_pos(bio, match_ends)
+            r = p1:p2
+            bio = new(s, r, length(r))
+        end
+        seekstart(bio)
+        bio
+    end
+end
+
+BlockIO(bio::BlockIO, match_ends::Union{Char,Void}=nothing) = BlockIO(bio.s, bio.r, match_ends)
+
+close(bio::BlockIO) = close(bio.s)
+eof(bio::BlockIO) = (position(bio) >= bio.l)
+read(bio::BlockIO, x::Type{UInt8}) = read(bio.s, x)
+read!(bio::BlockIO, a::Vector{UInt8}) = (length(a) <= nb_available(bio)) ? read!(bio.s, a) : throw(EOFError())
+read!(bio::BlockIO, a::Array{T}) where {T} = (length(a)*sizeof(T) <= nb_available(bio)) ? read!(bio.s, a) : throw(EOFError())
+
+read(bio::BlockIO, nb::Integer = bio.l) = String(read!(bio, Array{UInt8}(nb)))
+
+peek(bio::BlockIO) = peek(bio.s)
+write(bio::BlockIO, p::Ptr, nb::Integer) = write(bio, p, int(nb))
+write(bio::BlockIO, p::Ptr, nb::Int) = write(bio.s, p, nb)
+write(bio::BlockIO, x::UInt8) = write(bio, UInt8[x])
+write(bio::BlockIO, a::Array{T}, len) where {T} = write_sub(bio, a, 1, len)
+write(bio::BlockIO, a::Array{T}) where {T} = write(bio, a, length(a))
+write_sub(bio::BlockIO, a::Array{T}, offs, len) where {T} = isbits(T) ? write(bio, pointer(a,offs), len*sizeof(T)) : error("$T is not bits type")
+
+nb_available(bio::BlockIO) = (bio.l - position(bio))
+position(bio::BlockIO) = position(bio.s) - bio.r.start + 1
+
+filesize(bio::BlockIO) = bio.l
+
+seek(bio::BlockIO, n::Integer) = seek(bio.s, n+bio.r.start-1)
+seekend(bio::BlockIO) = seek(bio, filesize(bio))
+seekstart(bio::BlockIO) = seek(bio, 0)
+skip(bio::BlockIO, n::Integer) = seek(bio, n+position(bio))
+
+# it returns a IOBuffer, not String
+function readuntil(bio::BlockIO, dlm::Char, n::Int)
+    io = IOBuffer()
+    i = 0
+    while !eof(bio)
+        c = read(bio, Char)
+        write(io, c)
+        c == dlm && (i += 1)
+        i == n && break
+    end
+    seekstart(io)
+end
+
+blocksize(s, n) = ceil(Int, s / n)
+
+function blocks(fname, dlm = '\n', n = length(workers()))
+    s = filesize(fname)
+    bs = blocksize(s, n)
+    @assert(bs > 1, "wow, you have sooo many workers")
+
+    start = 1
+    stop = 1
+    offset = 0  # bs offset
+    bios = Vector{BlockIO}(n)
+
+    for i ∈ 1:n
+        stop = start + offset + bs - 1
+        r = start:stop
+        bio = BlockIO(open(fname), r, dlm)
+        stop′ = bio.r.stop  # get relocated ending position
+        start = stop′
+        offset = stop′ - stop
+        bios[i] = bio
+    end
+
+    @assert sum(filesize.(bios)) == s
+
+    bios
+end
+
+###############################################################################
+#  ChunkIter
+###############################################################################
+
+struct ChunkIter
+    io::IO
+    dlm::Char
+    n::Int
+end
+
+ChunkIter(fname::String, dlm::Char = '\n', n::Int = 1000) =
+    ChunkIter(open(fname), dlm, n)
+
+start(i::ChunkIter) = 1
+next(i::ChunkIter, s) = readuntil(i.io, i.dlm, i.n), s + 1
+done(i::ChunkIter, s) = eof(i.io)
+
+###############################################################################
+#  Usage
+###############################################################################
+
+# addprocs()
+# fname = "path/to/file.csv"
+# bios = JuliaDB.blocks(fname)
+# b = bios[1]
+# iter = ChunkIter(b, '\n', 10)
+# readdlm(next(iter, 42)[1], ',')

--- a/src/io.jl
+++ b/src/io.jl
@@ -212,3 +212,24 @@ function _makerelative!(t, dir::AbstractString)
         end
     end
 end
+
+struct ChunkIter
+    io::IO
+    dlm::Char
+    n::Int
+    buff::Array{String,1}
+end
+
+ChunkIter(fname::String, dlm::Char = ',', n::Int = 1000) =
+    ChunkIter(open(fname), dlm, n, Array{String,1}(n))
+
+start(i::ChunkIter) = 1
+
+function next(i::ChunkIter, s)
+    for j ∈ 1:i.n
+        i.buff[j] = readline(i.io)
+    end
+    i.buff, s + 1
+end
+
+done(i::ChunkIter, s) = eof(i.io)

--- a/src/io.jl
+++ b/src/io.jl
@@ -212,24 +212,3 @@ function _makerelative!(t, dir::AbstractString)
         end
     end
 end
-
-struct ChunkIter
-    io::IO
-    dlm::Char
-    n::Int
-    buff::Array{String,1}
-end
-
-ChunkIter(fname::String, dlm::Char = ',', n::Int = 1000) =
-    ChunkIter(open(fname), dlm, n, Array{String,1}(n))
-
-start(i::ChunkIter) = 1
-
-function next(i::ChunkIter, s)
-    for j ∈ 1:i.n
-        i.buff[j] = readline(i.io)
-    end
-    i.buff, s + 1
-end
-
-done(i::ChunkIter, s) = eof(i.io)


### PR DESCRIPTION
Follow the issue #127.
Just provide a POC here.

And... I have no idea how to integrate this with Dagger or some parallel mechanism.
Also, its performance might not be perfect.
Please comment. :)

----
```julia
julia> i = JuliaDB.ChunkIter(fname, ',', 10)
JuliaDB.ChunkIter(IOStream(<file /opt/data/taq/trade-2017.csv>), ',', 10, String[#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #$
ndef, #undef])                                          
                                                        
julia> next(i,1)[1]                                      
10-element Array{String,1}:                              
 "DATE,TIME_M,EX,SYM_ROOT,SYM_SUFFIX,TR_SCOND,SIZE,PRICE,TR_CORR,TR_SEQNUM,TR_SOURCE,TR_RF"
 "20170103,9:30:00.049256000,Z,A,,@,100,45.93,00,1915,C,"
 "20170103,9:30:00.049284000,K,A,,@,100,45.91,00,1916,C," 
 "20170103,9:30:00.049424000,T,A,,T,100,45.93,00,1917,C,"   
 "20170103,9:30:00.062678000,P,A,,@,400,45.74,00,1965,C,"
 "20170103,9:30:00.062702000,P,A,,Q,400,45.74,00,1966,C,"
 "20170103,9:30:00.066469000,P,A,,@,200,45.74,00,1973,C,"
 "20170103,9:30:00.179442000,T,A,,O X,100,45.93,00,2049,C,"
 "20170103,9:30:00.179463000,T,A,,Q,100,45.93,00,2050,C,"
 "20170103,9:30:01.004454000,N,A,,O,24505,45.95,00,2173,C,"

julia> next(i,1)[1]    
10-element Array{String,1}:                       
 "20170103,9:30:01.023823000,P,A,,I,17,45.94,00,2312,C,"
 "20170103,9:30:01.023959000,P,A,,I,17,45.94,00,2313,C,"
 "20170103,9:30:01.234458000,Z,A,,@,100,45.92,00,2382,C,"
 "20170103,9:30:01.234482000,K,A,,@,100,45.92,00,2383,C,"
 "20170103,9:30:01.248261000,P,A,,F,100,45.92,00,2384,C,"
 "20170103,9:30:01.649623000,K,A,,F,120,45.95,00,2468,C,"
 "20170103,9:30:02.997388000,D,A,,@,300,45.96,00,2680,C,T"
 "20170103,9:30:03.364572000,D,A,,@,100,45.9544,00,2789,C,N"
 "20170103,9:30:05.445397000,N,A,,@,100,45.98,00,3104,C,"
 "20170103,9:30:05.445418000,N,A,,@,100,45.98,00,3105,C,"
```