### PR TITLE
use GR instead of plotly

### DIFF
--- a/docs/src/api/plotting.md
+++ b/docs/src/api/plotting.md
@@ -2,7 +2,9 @@
 
 ```@setup plot
 Pkg.add("StatPlots")
+Pkg.add("GR")
 using StatPlots
+gr()
 ```
 
 ## StatPlots


### PR DESCRIPTION
Plots aren't showing up in http://juliadb.org/latest/api/plotting.html because saving with png isn't supported by the default (plotly) backend.  This PR switches the backend to GR.