### PR TITLE
Fix exports (add AbstractNDSparse, remove permutecols)

### DIFF
--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -11,10 +11,10 @@ import Dagger: compute, distribute, free!, gather, load, save
 using DataValues
 
 # re-export
-export IndexedTable, NDSparse, NextTable, Columns, colnames,
+export IndexedTable, AbstractNDSparse, NDSparse, NextTable, Columns, colnames,
        table, ndsparse, compute, groupby, summarize, groupreduce, groupjoin,
        ColDict, insertafter!, insertbefore!, @cols, setcol, pushcol,
-       popcol, insertcol, insertcolafter, insertcolbefore, permutecols,
+       popcol, insertcol, insertcolafter, insertcolbefore,
        renamecol, NA, dropna, flatten, ML, All, Not, Between, Keys
 
 include("util.jl")


### PR DESCRIPTION
My package [ModuleInterfaceTools](https://github.com/JuliaString/ModuleInterfaceTools.jl) checks to see if anything exported from a package it is using or importing actually exists (to allow renaming, i.e. `const foo = ThatPkg.bar`), and it detected that permutecols was not defined anywhere.
Also, `AbstractNDSparse` is needed to deal with writing generic code for NDSparse & DNDSparse tables.