### PR TITLE
WIP: add interactive recipe for OnlineStats plot

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,3 +10,5 @@ PooledArrays 0.2.1
 WeakRefStrings
 StatsBase
 DataValues
+Widgets 0.2.2
+Observables 0.1.2

--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -3,6 +3,9 @@ module JuliaDB
 
 using IndexedTables, Dagger, NamedTuples, OnlineStats
 
+import Observables, Widgets
+using Widgets: @nodeps, @widget, @layout!, @output!, div
+
 import Base: collect, select, join
 import IndexedTables: NextTable, table, NDSparse, ndsparse, Tup, groupjoin
 import TextParse: csvread
@@ -50,6 +53,7 @@ include("join.jl")
 
 include("diagnostics.jl")
 include("recipes.jl")
+include("interactiverecipes.jl")
 include("ml.jl")
 
 end # module

--- a/src/interactiverecipes.jl
+++ b/src/interactiverecipes.jl
@@ -1,0 +1,20 @@
+@widget wdg function interactivepartition(t; throttle = 0.1)
+    :x =  @nodeps dropdown(colnames(t), label = "x")
+    :y =  @nodeps dropdown(vcat(Symbol(""), colnames(t)), label = "y")
+    :nparts =  @nodeps slider(1:200, value = 100, label = "number of partitions")
+    :nparts_throttle = Observables.throttle(throttle, :nparts)
+    :dropmissing = @nodeps toggle(false, label = "dropmissing")
+    :by = @nodeps dropdown(colnames(t), multiple = true)
+    wdg[:split] = @nodeps togglecontent(div("by", wdg[:by]), value = false, label = "spit data")
+    :plot = @nodeps button("plot")
+     @output! wdg begin
+        $(:plot)
+        y = :y[] == Symbol("") ? [] : [:y[]]
+        by = (!(:split[]) || isempty(:by[])) ? nothing : Tuple(:by[])
+        partitionplot(t, :x[], y..., by = by, nparts = $(:nparts_throttle), dropmissing = :dropmissing[])
+     end
+    @layout! wdg begin
+        controls = div(:x, :y,  :split, :dropmissing, :plot)
+        div(controls, div(_.output, :nparts), style = Dict("display" => "flex", "flex-direction"=>"row"))
+    end
+end


### PR DESCRIPTION
Still needs tests and docs and I need to allow the user to choose what statistics to run. Of course the layout should be worked on, not sure what option is best but am open to suggestions. Here the user can choose x axis, optionally y axis, whether they want to split the data and by which variables, whether they want to drop missing data and the number of partitions. Only plot button and number of partition slider cause the plot to update.

@joshday I may need some help as I don't know OnlineStats that much. Is there a list of statistics that it makes sense to use for this kind of plot? Do they all have a version with zero arguments (say `Extrema()`)?

![interactivepartition](https://user-images.githubusercontent.com/6333339/43004475-ce7a1bd0-8c27-11e8-841a-cfb4843ab346.png)
