### PR TITLE
join cleanup

### DIFF
--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -409,6 +409,8 @@ end
 
 _promote_type(T,S) = promote_type(T,S)
 _promote_type(T::Type{<:IndexTuple}, S::Type{<:IndexTuple}) = map_params(_promote_type, T, S)
+_promote_type(T::Type{<:IndexTuple}, ::Type{Union{}}) = T
+_promote_type(::Type{Union{}}, S::Type{<:IndexTuple}) = S
 
 function getkvtypes(xs::AbstractArray)
     kvtypes = getkvtypes.(chunktype.(xs))

--- a/src/ndsparse.jl
+++ b/src/ndsparse.jl
@@ -210,6 +210,10 @@ Base.map(f, dt::DNDSparse) = mapchunks(c->map(f, c), dt)
 
 struct EmptySpace{T} end
 
+has_empty_values(domain::Pair{<:Any, <:EmptySpace}) = true
+has_empty_values(domain::EmptySpace) = true
+has_empty_values(domain) = false
+
 # Teach dagger how to automatically figure out the
 # metadata (in dagger parlance "domain") about an NDSparse chunk.
 function Dagger.domain(nd::NDSparse)

--- a/src/table.jl
+++ b/src/table.jl
@@ -173,6 +173,7 @@ function fromchunks(::Type{<:IndexedTable}, chunks::AbstractArray;
 end
 
 function promote_eltypes(ts::AbstractArray)
+    ts = filter(!isempty, ts)
     t = eltype(ts[1])
     for i = 2:length(ts)
         t = _promote_type(t, eltype(ts[i]))
@@ -181,6 +182,7 @@ function promote_eltypes(ts::AbstractArray)
 end
 
 function promote_eltype_chunktypes(ts::AbstractArray)
+    ts = filter(!isempty∘last∘domain, ts)
     t = eltype(chunktype(ts[1]))
     for i = 2:length(ts)
         t = _promote_type(t, eltype(chunktype(ts[i])))

--- a/src/table.jl
+++ b/src/table.jl
@@ -172,10 +172,6 @@ function fromchunks(::Type{<:IndexedTable}, chunks::AbstractArray;
     DIndexedTable{T, K}(pkey, domains, chunks[nzidxs])
 end
 
-has_empty_values(domain::Pair{<:Any, <:EmptySpace}) = true
-has_empty_values(domain::EmptySpace) = true
-has_empty_values(domain) = false
-
 function promote_eltypes(ts::AbstractArray)
     nonempty_domains = Iterators.filter(!has_empty_values, ts)
     mapreduce(eltype, _promote_type, nonempty_domains, init = Union{})


### PR DESCRIPTION
I've removed `keepkeys` as it was also removed from IndexedTables. The only important change here (hope the implementation is correct) is that in `promote_eltypes` we need to ignore empty chunks, as in empty chunks, without using inference, it's hard to guess the eltype.

EDIT: the implementation is actually not correct, I'm not sure what's the cleanest way to check whether a chunk is empty.