### PR TITLE
update to IndexedTables column API refactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 [compat]
 Dagger = "≥ 0.8.0"
 Glob = "≥ 1.2.0"
-IndexedTables = "≥ 0.10.0"
+IndexedTables = "≥ 0.12.1"
 MemPool = "≥ 0.2.0"
 OnlineStats = "≥ 0.17.0"
 PooledArrays = "≥ 0.4.1"

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -60,7 +60,7 @@ nd[1, :]
 
 JuliaDB has a variety of ways to select columns.  These selection methods get used across
 many JuliaDB's functions: [`select`](@ref), [`reduce`](@ref), [`groupreduce`](@ref), 
-[`groupby`](@ref), [`join`](@ref), [`pushcol`](@ref), [`reindex`](@ref), and more.
+[`groupby`](@ref), [`join`](@ref), [`transform`](@ref), [`reindex`](@ref), and more.
 
 To demonstrate selection, we'll use the [`select`](@ref) function.  A selection can be any
 of the following types:

--- a/docs/src/ml.md
+++ b/docs/src/ml.md
@@ -11,7 +11,7 @@ download("https://raw.githubusercontent.com/agconti/"*
           "kaggle-titanic/master/data/train.csv", "train.csv")
 
 train_table = loadtable("train.csv", escapechar='"')
-popcol(popcol(popcol(train_table, :Name), :Ticket), :Cabin) # hide
+select(train_table, Not((:Name, :Ticket, :Cabin))) # hide
 ```
 
 ## ML.schema

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -11,13 +11,11 @@ Depth = 2
 
 ## Column Operations
 
-- [`setcol`](@ref)
-- [`pushcol`](@ref)
-- [`popcol`](@ref)
-- [`insertcol`](@ref)
-- [`insertcolafter`](@ref)
-- [`insertcolbefore`](@ref)
-- [`renamecol`](@ref)
+- [`transform`](@ref)
+- [`insertcols`](@ref)
+- [`insertcolsafter`](@ref)
+- [`insertcolsbefore`](@ref)
+- [`rename`](@ref)
 
 ## [`filter`](@ref)
 
@@ -27,7 +25,7 @@ Depth = 2
 
 ## [`reduce`](@ref) and [`groupreduce`](@ref)
 
-## [`pushcol`](@ref)
+## [`transform`](@ref)
 
 ## [`stack`](@ref) and [`unstack`](@ref)
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -284,18 +284,18 @@ speed = map(i -> i.Distance / i.AirTime * 60, flights)
 
 ## Add new variables
 
-Use the `pushcol` function to add a column to an existing dataset:
+Use the `transform` function to add a column to an existing dataset:
 
 
 ```julia
-pushcol(flights, :Speed, speed)
+transform(flights, :Speed => speed)
 ```
 
 If you need to add the new column to the existing dataset:
 
 
 ```julia
-flights = pushcol(flights, :Speed, speed)
+flights = transform(flights, :Speed => speed)
 ```
 
 ## Reduce variables to values
@@ -621,7 +621,7 @@ For each month, calculate the number of flights and the change from the previous
 using ShiftedArrays
 y = groupby(length, flights, :Month)
 lengths = columns(y, :length)
-pushcol(y, :change, lengths .- lag(lengths))
+transform(y, :change => lengths .- lag(lengths))
 ```
 
     Table with 12 rows, 3 columns:

--- a/src/JuliaDB.jl
+++ b/src/JuliaDB.jl
@@ -29,11 +29,11 @@ export @cols, @dateformat_str, AbstractNDSparse, All, Between, ColDict, Columns,
     asofjoin, chunks, colnames, column, columns, compute, convertdim, 
     csvread, distribute, dropmissing, fetch_timings!, flatten, glob, groupby, groupjoin, 
     groupreduce, ingest, ingest!, innerjoin, insert_row!, insertafter!, insertbefore!, 
-    insertcol, insertcolafter, insertcolbefore, leftjoin, load, load_table, loadfiles, 
+    insertcols, insertcolsafter, insertcolsbefore, leftjoin, load, load_table, loadfiles, 
     loadndsparse, loadtable, merge, naturaljoin, ndsparse, pairs, partitionplot, 
-    partitionplot!, popcol, pushcol, rechunk, rechunk_together, reducedim_vec, reindex, 
-    renamecol, rows, save, select, selectkeys, selectvalues, setcol, stack, 
-    start_tracking_time, stop_tracking_time, summarize, table, tracktime, unstack,
+    partitionplot!, rechunk, rechunk_together, reducedim_vec, reindex, 
+    rename, rows, save, select, selectkeys, selectvalues, stack, 
+    start_tracking_time, stop_tracking_time, summarize, table, tracktime, transform, unstack,
     convertmissing
 
 include("util.jl")

--- a/test/test_iteration.jl
+++ b/test/test_iteration.jl
@@ -33,5 +33,5 @@
     @test collect(pairs(y)) == [(a=1,b=1)=>3, (a=1,b=2)=>4]
 
     x = ndsparse(([1,2], [3,4]), (x=[0,1],), chunks=2)
-    @test ndsparse(keys(x), pushcol(values(x), :y, [1,2])) == ndsparse(([1,2], [3,4]), (x=[0,1], y=[1,2]))
+    @test ndsparse(keys(x), transform(values(x), :y => [1,2])) == ndsparse(([1,2], [3,4]), (x=[0,1], y=[1,2]))
 end

--- a/test/test_table.jl
+++ b/test/test_table.jl
@@ -1,6 +1,6 @@
 @everywhere using Statistics
 
-import JuliaDB: pkeynames, pkeys, excludecols, select
+import JuliaDB: pkeynames, pkeys, excludecols, select, transform
 
 @testset "table" begin
     t = table([1, 1, 1, 2, 2, 2], [1, 1, 2, 2, 1, 1], [1, 2, 3, 4, 5, 6], names=[:x, :y, :z], pkey=(:x, :y), chunks=2)
@@ -75,23 +75,23 @@ import JuliaDB: pkeynames, pkeys, excludecols, select
     @test rows(t, (:x,)) == Columns((x = [1, 2],))
     @test rows(t, (:y, :x => (-))) == Columns((y = [3, 4], x = [-1, -2]))
     t = table([1, 2], [3, 4], names=[:x, :y], chunks=2)
-    @test setcol(t, 2, [5, 6]) == table([1, 2], [5, 6], names=Symbol[:x, :y])
-    @test setcol(t, :x, :x => (x->1 / x)) == table([1.0, 0.5], [3, 4], names=Symbol[:x, :y])
+    @test transform(t, 2 => [5, 6]) == table([1, 2], [5, 6], names=Symbol[:x, :y])
+    @test transform(t, :x => :x => (x->1 / x)) == table([1.0, 0.5], [3, 4], names=Symbol[:x, :y])
     t = table([0.01, 0.05], [1, 2], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    t2 = setcol(t, :t, [0.1, 0.05])
+    t2 = transform(t, :t => [0.1, 0.05])
     @test t2 == table([0.05, 0.1], [2,1], [4,3], names=[:t,:x,:y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    @test pushcol(t, :z, [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], Rational{Int64}[1//2, 3//4], names=Symbol[:t, :x, :y, :z])
+    @test transform(t, :z => [1 // 2, 3 // 4]) == table([0.01, 0.05], [2, 1], [3, 4], Rational{Int64}[1//2, 3//4], names=Symbol[:t, :x, :y, :z])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    @test popcol(t, :x) == table([0.01, 0.05], [3, 4], names=Symbol[:t, :y])
+    @test select(t, Not(:x)) == table([0.01, 0.05], [3, 4], names=Symbol[:t, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    @test insertcol(t, 2, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcols(t, 2, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    @test insertcolafter(t, :t, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcolsafter(t, :t, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], [3, 4], names=[:t, :x, :y], pkey=:t, chunks=2)
-    @test insertcolbefore(t, :x, :w, [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
+    @test insertcolsbefore(t, :x, :w => [0, 1]) == table([0.01, 0.05], [0, 1], [2, 1], [3, 4], names=Symbol[:t, :w, :x, :y])
     t = table([0.01, 0.05], [2, 1], names=[:t, :x], chunks=2)
-    @test renamecol(t, :t, :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
+    @test rename(t, :t => :time) == table([0.01, 0.05], [2, 1], names=Symbol[:time, :x])
     l = table([1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 3, 4], names=[:a, :b, :c], pkey=(:a, :b), chunks=2)
     r = table([0, 1, 1, 3], [1, 1, 2, 2], [1, 2, 3, 4], names=[:a, :b, :d], pkey=(:a, :b), chunks=2)
     @test join(l, r) == table([1, 1], [1, 2], [1, 2], [2, 3], names=[:a, :b, :c, :d])


### PR DESCRIPTION
This updates docstrings, exports and tests to the new IndexedTables column API (which we discussed in https://github.com/JuliaComputing/IndexedTables.jl/issues/239). I'm removing exports of deprecated functions (`pushcol`, `popcol`, `setcol`, `insertcol(before/after)`) has they have been deprecated for a while now.

Fix #303.